### PR TITLE
Clean config

### DIFF
--- a/configs/dataset/dedo.yaml
+++ b/configs/dataset/dedo.yaml
@@ -1,4 +1,8 @@
 name: dedo
+
+#####################################################
+# Dataset Parameters
+#####################################################
 data_dir: "~/data/"
 task: proccloth
 robot: True
@@ -11,9 +15,17 @@ sample_size_action: 512
 sample_size_anchor: 512
 downsample_type: fps
 
-noisy_goal: False
+#####################################################
+# Model Data-processing Parameters
+#####################################################
+# These are set by the model config.
+noisy_goal: null # if True, use noisy action goal centroid
+center_type: null # [action_center, anchor_center, scene_center, none], centers the point clouds
+action_context_center_type: null # [center, random, none], centers the action context point clouds
 
-# Environment specific params.
+#####################################################
+# Environment-specific Parameters
+#####################################################
 cloth_geometry: multi
 cloth_pose: random
 anchor_geometry: single
@@ -22,11 +34,15 @@ num_anchors: 2
 hole: single
 
 # Dataset pre-processing options
-center_type: anchor_center # [action_center, anchor_center, anchor_random, scene_center, none], centers the point clouds w.r.t. the action, anchor, or no centering
-action_context_center_type: center # [center, random, none], centers the action context point clouds
-pcd_scale_factor: 1.0 # Scale factor for the point clouds
+# center_type: anchor_center # [action_center, anchor_center, anchor_random, scene_center, none], centers the point clouds w.r.t. the action, anchor, or no centering
+# action_context_center_type: center # [center, random, none], centers the action context point clouds
 # action_transform_type: identity # Transformation type to apply to demonstrations
 # anchor_transform_type: random_flat_upright # Transformation type to apply to demonstrations
+
+#####################################################
+# Data Processing/Augmentation Parameters
+#####################################################
+pcd_scale_factor: 1.0 # Scale factor for the point clouds
 scene_transform_type: random_flat_upright # Transformation type to apply to the scene
 translation_variance: 0.0 # Translation variance of the demo transformation
 rotation_variance: 180 # Rotation variance of the demo transformation

--- a/configs/dataset/dedo.yaml
+++ b/configs/dataset/dedo.yaml
@@ -4,8 +4,6 @@ name: dedo
 # Dataset Parameters
 #####################################################
 data_dir: "~/data/"
-task: proccloth
-robot: True
 material: deform
 
 train_size: null # (int, null) Length of the train dataset
@@ -31,6 +29,8 @@ pcd_scale: 12.0 # Scale range for the point clouds
 #####################################################
 # Environment-specific Parameters
 #####################################################
+task: proccloth
+robot: True
 cloth_geometry: multi
 cloth_pose: random
 anchor_geometry: single

--- a/configs/dataset/dedo.yaml
+++ b/configs/dataset/dedo.yaml
@@ -24,6 +24,11 @@ center_type: null # [action_center, anchor_center, scene_center, none], centers 
 action_context_center_type: null # [center, random, none], centers the action context point clouds
 
 #####################################################
+# Dataset-specific Model Parameters
+#####################################################
+pcd_scale: 12.0 # Scale range for the point clouds
+
+#####################################################
 # Environment-specific Parameters
 #####################################################
 cloth_geometry: multi

--- a/configs/dataset/dedo.yaml
+++ b/configs/dataset/dedo.yaml
@@ -2,7 +2,6 @@ name: dedo
 data_dir: "~/data/"
 task: proccloth
 robot: True
-type: flow
 material: deform
 
 train_size: null # (int, null) Length of the train dataset
@@ -12,8 +11,6 @@ sample_size_action: 512
 sample_size_anchor: 512
 downsample_type: fps
 
-scene: True
-world_frame: True
 noisy_goal: False
 
 # Environment specific params.

--- a/configs/model/df_cross.yaml
+++ b/configs/model/df_cross.yaml
@@ -7,8 +7,6 @@ type: point # (flow, point) Type of model
 size: xS # (xs, s, ...) Architecture of DiT
 in_channels: 3 # Number of input channels
 learn_sigma: True # Learn sigma for diffusion
-center_noise: False # Center noise for diffusion
-rotary: False # Use rotary embedding for diffusion
 cross_atten: True # Use cross attention for diffusion
 feature: off # (flow, point, off) Type of feature base
 encoder_backbone: mlp # (mlp, pn2)

--- a/configs/model/df_cross.yaml
+++ b/configs/model/df_cross.yaml
@@ -9,11 +9,6 @@ in_channels: 3 # Number of input channels
 learn_sigma: True # Learn sigma for diffusion
 cross_atten: True # Use cross attention for diffusion
 feature: off # (flow, point, off) Type of feature base
-# encoder_backbone: mlp # (mlp, pn2)
-
-# x_encoder: mlp # Encoder current timestep x
-# y_encoder: mlp # (mlp, dgcnn) Encoder for y object (e.g. anchor pcd)
-# x0_encoder: mlp # (mlp, dgcnn) Encoder for x0 object (e.g. action pcd)
 point_encoder: mlp # (mlp, pn2) Point cloud encoder architecture
 
 #####################################################

--- a/configs/model/df_cross.yaml
+++ b/configs/model/df_cross.yaml
@@ -10,6 +10,7 @@ learn_sigma: True # Learn sigma for diffusion
 cross_atten: True # Use cross attention for diffusion
 point_encoder: mlp # (mlp, pn2) Point cloud encoder architecture
 feature: False # If True, encode additional features
+joint_encode: False # If True, use joint encoding for point cloud feature
 
 #####################################################
 # Model-specific Dataset Parameters

--- a/configs/model/df_cross.yaml
+++ b/configs/model/df_cross.yaml
@@ -8,8 +8,8 @@ size: xS # (xs, s, ...) Architecture of DiT
 in_channels: 3 # Number of input channels
 learn_sigma: True # Learn sigma for diffusion
 cross_atten: True # Use cross attention for diffusion
-feature: off # (flow, point, off) Type of feature base
 point_encoder: mlp # (mlp, pn2) Point cloud encoder architecture
+feature: False # If True, encode additional features
 
 #####################################################
 # Model-specific Dataset Parameters

--- a/configs/model/df_cross.yaml
+++ b/configs/model/df_cross.yaml
@@ -9,18 +9,25 @@ in_channels: 3 # Number of input channels
 learn_sigma: True # Learn sigma for diffusion
 cross_atten: True # Use cross attention for diffusion
 feature: off # (flow, point, off) Type of feature base
-encoder_backbone: mlp # (mlp, pn2)
+# encoder_backbone: mlp # (mlp, pn2)
 
-x_encoder: mlp # Encoder current timestep x
-y_encoder: mlp # (mlp, dgcnn) Encoder for y object (e.g. anchor pcd)
-x0_encoder: mlp # (mlp, dgcnn) Encoder for x0 object (e.g. action pcd)
+# x_encoder: mlp # Encoder current timestep x
+# y_encoder: mlp # (mlp, dgcnn) Encoder for y object (e.g. anchor pcd)
+# x0_encoder: mlp # (mlp, dgcnn) Encoder for x0 object (e.g. action pcd)
+point_encoder: mlp # (mlp, pn2) Point cloud encoder architecture
 
 #####################################################
-# Model Data-processing Parameters
+# Model-specific Dataset Parameters
 #####################################################
 noisy_goal: False # if True, use noisy action goal centroid
 center_type: anchor_center # [action_center, anchor_center, scene_center, none], centers the point clouds
 action_context_center_type: center # [center, random, none], centers the action context point clouds
+
+#####################################################
+# Dataset-specific Model Parameters
+#####################################################
+# These are set by the dataset config.
+pcd_scale: null # Scale range for the point clouds
 
 #####################################################
 # Model Diffusion Parameters

--- a/configs/model/df_cross.yaml
+++ b/configs/model/df_cross.yaml
@@ -1,6 +1,8 @@
 name: df_cross
 
-# Model settings
+#####################################################
+# Model Architecture Parameters
+#####################################################
 type: point # (flow, point) Type of model
 size: xS # (xs, s, ...) Architecture of DiT
 in_channels: 3 # Number of input channels
@@ -15,7 +17,16 @@ x_encoder: mlp # Encoder current timestep x
 y_encoder: mlp # (mlp, dgcnn) Encoder for y object (e.g. anchor pcd)
 x0_encoder: mlp # (mlp, dgcnn) Encoder for x0 object (e.g. action pcd)
 
-# diffusion settings
+#####################################################
+# Model Data-processing Parameters
+#####################################################
+noisy_goal: False # if True, use noisy action goal centroid
+center_type: anchor_center # [action_center, anchor_center, scene_center, none], centers the point clouds
+action_context_center_type: center # [center, random, none], centers the action context point clouds
+
+#####################################################
+# Model Diffusion Parameters
+#####################################################
 diff_train_steps: 100 # Number of diffusion steps during training
 diff_inference_steps: 100 # Number of diffusion steps during inference
 diff_noise_schedule: linear # (linear, cosine) Noise schedule for diffusion

--- a/scripts/train_deform.sh
+++ b/scripts/train_deform.sh
@@ -8,7 +8,7 @@
 # 5. the rest of the arguments for the train.py script
 
 # Example usage:
-# ./train_deform.sh 0 cross_flow_relative offline dedo
+# ./train_deform.sh 0 cross_flow offline dedo
 
 # Resuming from a crashed run:
 #./train_rigid.sh 0 ddrd_flow_separate rpdiff_fit online checkpoint.run_id=k8iy8vfo checkpoint.local_ckpt='/home/lyuxing/Desktop/tax3d_upgrade/scripts/logs/train_rpdiff_feature_df_cross/2025-03-02/17-41-55/checkpoints/last.ckpt'
@@ -24,12 +24,12 @@ shift
 COMMAND=$@
 DATASET_PARAMS="dataset=$DATASET_NAME"
 
-if [ $MODEL_TYPE == "cross_flow_relative" ]; then
+if [ $MODEL_TYPE == "cross_flow" ]; then
   echo "Training cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=df_cross model.type=flow"
 
-elif [ $MODEL_TYPE == "cross_point_relative" ]; then
+elif [ $MODEL_TYPE == "cross_point" ]; then
   echo "Training cross relative point model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=df_cross model.type=point"

--- a/scripts/train_deform.sh
+++ b/scripts/train_deform.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# This should take in 4 arguments:
+# 1. the index of which GPU to use
+# 2. model type
+# 3. WANDB mode
+# 4. dataset name
+# 5. the rest of the arguments for the train.py script
+
+# Example usage:
+# ./train_deform.sh 0 cross_flow_relative offline dedo
+
+# Resuming from a crashed run:
+#./train_rigid.sh 0 ddrd_flow_separate rpdiff_fit online checkpoint.run_id=k8iy8vfo checkpoint.local_ckpt='/home/lyuxing/Desktop/tax3d_upgrade/scripts/logs/train_rpdiff_feature_df_cross/2025-03-02/17-41-55/checkpoints/last.ckpt'
+
+GPU_INDEX=$1
+MODEL_TYPE=$2
+WANDB_MODE=$3
+DATASET_NAME=$4
+shift
+shift
+shift
+shift
+COMMAND=$@
+
+if [ $MODEL_TYPE == "cross_flow_relative" ]; then
+  echo "Training cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=df_cross model.type=flow"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+
+elif [ $MODEL_TYPE == "cross_point_relative" ]; then
+  echo "Training cross relative point model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=df_cross model.type=point"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=point dataset.noisy_goal=False"
+
+elif [ $MODEL_TYPE == "feature_df_cross" ]; then
+  echo "Training feature cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=feature_df_cross model.type=flow"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+elif [ $MODEL_TYPE == "pn2_df_cross" ]; then
+  echo "Training pointnet++ w/ cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=pn2_df_cross model.type=flow"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+elif [ $MODEL_TYPE == "pn2_feature_df_cross" ]; then
+  echo "Training pointnet++ w/ feature cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=pn2_feature_df_cross model.type=flow"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+elif [ $MODEL_TYPE == "ddrd_point_joint" ]; then
+  echo "Training DDRD point joint model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=ddrd model.type=point model.model_take=joint"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=point dataset.noisy_goal=False"
+elif [ $MODEL_TYPE == "ddrd_flow_joint" ]; then
+  echo "Training DDRD flow joint model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=ddrd model.type=flow model.model_take=joint"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+elif [ $MODEL_TYPE == "ddrd_point_separate" ]; then
+  echo "Training DDRD point separate model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=ddrd model.type=point model.model_take=separate"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=point dataset.noisy_goal=False"
+elif [ $MODEL_TYPE == "ddrd_flow_separate" ]; then
+  echo "Training DDRD flow separate model on dataset $DATASET_NAME with command: $COMMAND."
+
+  MODEL_PARAMS="model=ddrd model.type=flow model.model_take=separate"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+fi
+
+WANDB_MODE=$WANDB_MODE python train.py \
+  $MODEL_PARAMS \
+  $DATASET_PARAMS \
+  wandb.group=tax3d_upgrade_rigid \
+  resources.gpus=[${GPU_INDEX}] \
+  $COMMAND

--- a/scripts/train_deform.sh
+++ b/scripts/train_deform.sh
@@ -27,49 +27,49 @@ if [ $MODEL_TYPE == "cross_flow_relative" ]; then
   echo "Training cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 
 elif [ $MODEL_TYPE == "cross_point_relative" ]; then
   echo "Training cross relative point model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=df_cross model.type=point"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=point dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 
 elif [ $MODEL_TYPE == "feature_df_cross" ]; then
   echo "Training feature cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=feature_df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 elif [ $MODEL_TYPE == "pn2_df_cross" ]; then
   echo "Training pointnet++ w/ cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=pn2_df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 elif [ $MODEL_TYPE == "pn2_feature_df_cross" ]; then
   echo "Training pointnet++ w/ feature cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=pn2_feature_df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 elif [ $MODEL_TYPE == "ddrd_point_joint" ]; then
   echo "Training DDRD point joint model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=point model.model_take=joint"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=point dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 elif [ $MODEL_TYPE == "ddrd_flow_joint" ]; then
   echo "Training DDRD flow joint model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=flow model.model_take=joint"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 elif [ $MODEL_TYPE == "ddrd_point_separate" ]; then
   echo "Training DDRD point separate model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=point model.model_take=separate"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=point dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 elif [ $MODEL_TYPE == "ddrd_flow_separate" ]; then
   echo "Training DDRD flow separate model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=flow model.model_take=separate"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.type=flow dataset.noisy_goal=False"
+  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 fi
 
 WANDB_MODE=$WANDB_MODE python train.py \

--- a/scripts/train_deform.sh
+++ b/scripts/train_deform.sh
@@ -22,54 +22,53 @@ shift
 shift
 shift
 COMMAND=$@
+DATASET_PARAMS="dataset=$DATASET_NAME"
 
 if [ $MODEL_TYPE == "cross_flow_relative" ]; then
   echo "Training cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 
 elif [ $MODEL_TYPE == "cross_point_relative" ]; then
   echo "Training cross relative point model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=df_cross model.type=point"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
 
 elif [ $MODEL_TYPE == "feature_df_cross" ]; then
   echo "Training feature cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=feature_df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 elif [ $MODEL_TYPE == "pn2_df_cross" ]; then
   echo "Training pointnet++ w/ cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=pn2_df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 elif [ $MODEL_TYPE == "pn2_feature_df_cross" ]; then
   echo "Training pointnet++ w/ feature cross relative flow model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=pn2_feature_df_cross model.type=flow"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 elif [ $MODEL_TYPE == "ddrd_point_joint" ]; then
   echo "Training DDRD point joint model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=point model.model_take=joint"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 elif [ $MODEL_TYPE == "ddrd_flow_joint" ]; then
   echo "Training DDRD flow joint model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=flow model.model_take=joint"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 elif [ $MODEL_TYPE == "ddrd_point_separate" ]; then
   echo "Training DDRD point separate model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=point model.model_take=separate"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 elif [ $MODEL_TYPE == "ddrd_flow_separate" ]; then
   echo "Training DDRD flow separate model on dataset $DATASET_NAME with command: $COMMAND."
 
   MODEL_PARAMS="model=ddrd model.type=flow model.model_take=separate"
-  DATASET_PARAMS="dataset=$DATASET_NAME dataset.noisy_goal=False"
+
 fi
 
 WANDB_MODE=$WANDB_MODE python train.py \

--- a/src/non_rigid/datasets/dedo.py
+++ b/src/non_rigid/datasets/dedo.py
@@ -34,15 +34,6 @@ class DedoDataset(data.Dataset):
         # setting sample sizes
         self.sample_size_action = self.dataset_cfg.sample_size_action
         self.sample_size_anchor = self.dataset_cfg.sample_size_anchor
-
-        # additional dataset params
-        self.scene = self.dataset_cfg.scene
-        self.world_frame = self.dataset_cfg.world_frame
-        
-        # TODO: this is here for consistency; just error out for scene-level dataset
-        # experiments from now on should just be object-level
-        if self.scene:
-            raise NotImplementedError("Scene-level DEDO dataset not yet implemented.")
         
     def __len__(self):
         return self.size
@@ -202,11 +193,6 @@ class DedoDataModule(L.LightningDataModule):
             self.dataset_cfg.scene_transform_type = "identity"
             self.dataset_cfg.rotation_variance = 0.0
             self.dataset_cfg.translation_variance = 0.0
-        # if world frame, don't mean-center the point clouds
-        if self.dataset_cfg.world_frame:
-            print("-------Turning off mean-centering for world frame predictions.-------")
-            self.dataset_cfg.center_type = "none"
-            self.dataset_cfg.action_context_center_type = "none"
 
         # initializing datasets
         self.train_dataset = DedoDataset(self.root, self.dataset_cfg, "train_tax3d")
@@ -244,7 +230,6 @@ class DedoDataModule(L.LightningDataModule):
 def cloth_collate_fn(batch):
     # batch can contain a list of dictionaries
     # we need to convert those to a dictionary of lists
-    # dict_keys = ["deform_transform", "rigid_transform", "deform_params", "rigid_params"]
     dict_keys = ["deform_data", "rigid_data"]
     keys = batch[0].keys()
     out = {k: None for k in keys}

--- a/src/non_rigid/models/df_base.py
+++ b/src/non_rigid/models/df_base.py
@@ -23,7 +23,6 @@ from non_rigid.models.dit.diffusion import create_diffusion
 from non_rigid.models.dit.models import DiT_PointCloud_Unc as DiT_pcu
 from non_rigid.models.dit.models import (
     DiT_PointCloud_Unc_Cross,
-    Rel3D_DiT_PointCloud_Unc_Cross,
     DiT_PointCloud_Cross,
     DiT_PointCloud
 )
@@ -43,12 +42,6 @@ def DiT_pcu_cross_xS(**kwargs):
     return DiT_PointCloud_Unc_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
 
-def Rel3D_DiT_pcu_cross_xS(**kwargs):
-    # Embed dim divisible by 3 for 3D positional encoding and divisible by num_heads for multi-head attention
-    return Rel3D_DiT_PointCloud_Unc_Cross(
-        depth=5, hidden_size=132, num_heads=4, **kwargs
-    )
-
 def DiT_PointCloud_Cross_xS(use_rotary, **kwargs):
     # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
     hidden_size = 132 if use_rotary else 128
@@ -64,8 +57,6 @@ DiT_models = {
     "DiT_pcu_S": DiT_pcu_S,
     "DiT_pcu_xS": DiT_pcu_xS,
     "DiT_pcu_cross_xS": DiT_pcu_cross_xS,
-    "Rel3D_DiT_pcu_cross_xS": Rel3D_DiT_pcu_cross_xS,
-    # there is no Rel3D_DiT_pcu_xS
     "DiT_PointCloud_Cross_xS": DiT_PointCloud_Cross_xS,
     # TODO: add the SD model here
     "DiT_PointCloud_xS": DiT_PointCloud_xS,
@@ -73,7 +64,6 @@ DiT_models = {
 
 
 def get_model(model_cfg):
-    #rotary = "Rel3D_" if model_cfg.rotary else ""
     cross = "Cross_" if model_cfg.name == "df_cross" else ""
     # model_name = f"{rotary}DiT_pcu_{cross}{model_cfg.size}"
     model_name = f"DiT_PointCloud_{cross}{model_cfg.size}"

--- a/src/non_rigid/models/dit/models.py
+++ b/src/non_rigid/models/dit/models.py
@@ -650,7 +650,7 @@ class DiT_PointCloud_Cross(nn.Module):
         self.num_heads = num_heads
         self.model_cfg = model_cfg
 
-        # Initializing point cloud encoder wrapper
+        # Initializing point cloud encoder wrapper.
         if self.model_cfg.point_encoder == "mlp":
             encoder_fn = partial(mlp_encoder, in_channels=self.in_channels)
         elif self.model_cfg.point_encoder == "pn2":
@@ -658,13 +658,12 @@ class DiT_PointCloud_Cross(nn.Module):
         else:
             raise ValueError(f"Invalid point_encoder: {self.model_cfg.point_encoder}")
             
-        # x_encoder_hidden_dims = hidden_size // 2
-        # Creating base encoders - action (x0), anchor (y), and noised prediction (x)
+        # Creating base encoders - action (x0), anchor (y), and noised prediction (x).
         self.x_encoder = encoder_fn(out_channels=hidden_size)
         self.x0_encoder = encoder_fn(out_channels=hidden_size)
         self.y_encoder = encoder_fn(out_channels=hidden_size)
 
-        # Creating extra feature encoders, if necessary
+        # Creating extra feature encoders, if necessary.
         if self.model_cfg.feature:
             self.shape_encoder = encoder_fn(out_channels=hidden_size)
             self.flow_zeromean_encoder = encoder_fn(out_channels=hidden_size)
@@ -673,10 +672,10 @@ class DiT_PointCloud_Cross(nn.Module):
         else:
             self.action_mixer = mlp_encoder(2 * hidden_size, hidden_size)
         
-        # Timestamp embedding
+        # Timestamp embedding.
         self.t_embedder = TimestepEmbedder(hidden_size)
 
-        # DiT blocks
+        # DiT blocks.
         self.blocks = nn.ModuleList(
             [
                 DiTCrossBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio)
@@ -684,7 +683,7 @@ class DiT_PointCloud_Cross(nn.Module):
             ]
         )
 
-        # functionally setting patch size to 1 for a point cloud
+        # Final layer; functionally setting patch size to 1 for a point cloud.
         self.final_layer = FinalLayer(hidden_size, 1, self.out_channels)
         self.initialize_weights()
 
@@ -739,9 +738,7 @@ class DiT_PointCloud_Cross(nn.Module):
         # Encode base features - action (x0), anchor (y), and noised prediction (x).
         x_enc = self.x_encoder(x)
         x0_enc = self.x0_encoder(x0)
-        # x_enc = torch.cat([x_enc, x0_enc], dim=1).permute(0, 2, 1)
         y_enc = self.y_encoder(y).permute(0, 2, 1)
-        # y_enc = y_enc.permute(0, 2, 1)
 
         # Encode extra features, if necessary.
         if self.model_cfg.feature:
@@ -759,7 +756,7 @@ class DiT_PointCloud_Cross(nn.Module):
             action_features = [x_enc, x0_enc]
 
         # Compress action features to hidden size through action mixer.
-        x_enc = torch.cat(action_features, dim=1)#.permute(0, 2, 1)
+        x_enc = torch.cat(action_features, dim=1)
         x_enc = self.action_mixer(x_enc).permute(0, 2, 1)
 
         # Timestep embedding.

--- a/src/non_rigid/models/tax3d.py
+++ b/src/non_rigid/models/tax3d.py
@@ -99,8 +99,9 @@ DiT_models = {
 def get_model(model_cfg):
     cross = "Cross_" if model_cfg.cross_atten else ""
     feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
-    encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
-    model_name = f"{encoder}DiT_PointCloud_{cross}{feature}{model_cfg.size}"
+    # encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
+    # model_name = f"{encoder}DiT_PointCloud_{cross}{feature}{model_cfg.size}"
+    model_name = f"DiT_PointCloud_{cross}{feature}{model_cfg.size}"
     return DiT_models[model_name]
 
 

--- a/src/non_rigid/models/tax3d.py
+++ b/src/non_rigid/models/tax3d.py
@@ -98,10 +98,10 @@ DiT_models = {
 
 def get_model(model_cfg):
     cross = "Cross_" if model_cfg.cross_atten else ""
-    feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
+    # feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
     # encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
     # model_name = f"{encoder}DiT_PointCloud_{cross}{feature}{model_cfg.size}"
-    model_name = f"DiT_PointCloud_{cross}{feature}{model_cfg.size}"
+    model_name = f"DiT_PointCloud_{cross}{model_cfg.size}"
     return DiT_models[model_name]
 
 

--- a/src/non_rigid/models/tax3d.py
+++ b/src/non_rigid/models/tax3d.py
@@ -21,77 +21,81 @@ from non_rigid.metrics.error_metrics import get_pred_pcd_rigid_errors
 from non_rigid.metrics.flow_metrics import flow_cos_sim, flow_rmse, pc_nn
 from non_rigid.metrics.rigid_metrics import svd_estimation, translation_err, rotation_err
 from non_rigid.models.dit.diffusion import create_diffusion
-from non_rigid.models.dit.models import DiT_PointCloud_Unc as DiT_pcu
 from non_rigid.models.dit.models import (
-    DiT_PointCloud_Unc_Cross,
+    # DiT_PointCloud_Unc_Cross,
     DiT_PointCloud_Cross,
-    DiT_PointCloud,
-    DiT_PointCloud_Cross_Point_Feature,
-    DiT_PointCloud_Cross_Flow_Feature,
-    PN2_DiT_PointCloud_Cross,
-    PN2_DiT_PointCloud,
-    PN2_DiT_PointCloud_Cross_Flow_Feature,
+    DiT_PointCloud_Cross_Joint,
+    # DiT_PointCloud,
+    # DiT_PointCloud_Cross_Point_Feature,
+    # DiT_PointCloud_Cross_Flow_Feature,
+    # PN2_DiT_PointCloud_Cross,
+    # PN2_DiT_PointCloud,
+    # PN2_DiT_PointCloud_Cross_Flow_Feature,
 )
 from non_rigid.utils.logging_utils import viz_predicted_vs_gt
 from non_rigid.utils.pointcloud_utils import expand_pcd
 
 
-def DiT_pcu_S(**kwargs):
-    return DiT_pcu(depth=12, hidden_size=384, num_heads=6, **kwargs)
+# def DiT_pcu_S(**kwargs):
+#     return DiT_pcu(depth=12, hidden_size=384, num_heads=6, **kwargs)
 
 
-def DiT_pcu_xS(**kwargs):
-    return DiT_pcu(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def DiT_pcu_xS(**kwargs):
+#     return DiT_pcu(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
 
-def DiT_pcu_cross_xS(**kwargs):
-    return DiT_PointCloud_Unc_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def DiT_pcu_cross_xS(**kwargs):
+#     return DiT_PointCloud_Unc_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
 def DiT_PointCloud_Cross_xS(**kwargs):
     return DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_xS(**kwargs):
-    print("DiffusionTransformerNetwork: DiT_PointCloud_xS")
-    return DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
+def DiT_PointCloud_Cross_Joint_xS(**kwargs):
+    return DiT_PointCloud_Cross_Joint(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_Cross_Point_Feature_xS(**kwargs):
-    print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Point_Feature_xS")
-    return DiT_PointCloud_Cross_Point_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def DiT_PointCloud_xS(**kwargs):
+#     print("DiffusionTransformerNetwork: DiT_PointCloud_xS")
+#     return DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
-    print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Flow_Feature_xS")
-    return DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def DiT_PointCloud_Cross_Point_Feature_xS(**kwargs):
+#     print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Point_Feature_xS")
+#     return DiT_PointCloud_Cross_Point_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def PN2_DiT_PointCloud_Cross_xS(**kwargs):
-    print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_xS")
-    return PN2_DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
+#     print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Flow_Feature_xS")
+#     return DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def PN2_DiT_PointCloud_xS(**kwargs):
-    print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_xS")
-    return PN2_DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def PN2_DiT_PointCloud_Cross_xS(**kwargs):
+#     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_xS")
+#     return PN2_DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def PN2_DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
-    print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_Flow_Feature_xS")
-    return PN2_DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
+# def PN2_DiT_PointCloud_xS(**kwargs):
+#     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_xS")
+#     return PN2_DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
+
+# def PN2_DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
+#     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_Flow_Feature_xS")
+#     return PN2_DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
 # TODO: clean up all unused functions
 DiT_models = {
-    "DiT_pcu_S": DiT_pcu_S,
-    "DiT_pcu_xS": DiT_pcu_xS,
-    "DiT_pcu_cross_xS": DiT_pcu_cross_xS,
+    # "DiT_pcu_S": DiT_pcu_S,
+    # "DiT_pcu_xS": DiT_pcu_xS,
+    # "DiT_pcu_cross_xS": DiT_pcu_cross_xS,
     "DiT_PointCloud_Cross_xS": DiT_PointCloud_Cross_xS,
-    # TODO: add the SD model here
-    "DiT_PointCloud_xS": DiT_PointCloud_xS,
-    # option 1
-    "DiT_PointCloud_Cross_Point_Feature_xS": DiT_PointCloud_Cross_Point_Feature_xS,
-    # option 2
-    "DiT_PointCloud_Cross_Flow_Feature_xS": DiT_PointCloud_Cross_Flow_Feature_xS,
-    # TAX3D+PN2 (cross-atten)
-    "PN2_DiT_PointCloud_Cross_xS": PN2_DiT_PointCloud_Cross_xS,
-    # TAX3D+PN2 (self-atten)
-    "PN2_DiT_PointCloud_xS": PN2_DiT_PointCloud_xS,
-    # Feature_TAX3D+PN2
-    "PN2_DiT_PointCloud_Cross_Flow_Feature_xS": PN2_DiT_PointCloud_Cross_Flow_Feature_xS,
+    "DiT_PointCloud_Cross_Joint_xS": DiT_PointCloud_Cross_Joint_xS,
+    # # TODO: add the SD model here
+    # "DiT_PointCloud_xS": DiT_PointCloud_xS,
+    # # option 1
+    # "DiT_PointCloud_Cross_Point_Feature_xS": DiT_PointCloud_Cross_Point_Feature_xS,
+    # # option 2
+    # "DiT_PointCloud_Cross_Flow_Feature_xS": DiT_PointCloud_Cross_Flow_Feature_xS,
+    # # TAX3D+PN2 (cross-atten)
+    # "PN2_DiT_PointCloud_Cross_xS": PN2_DiT_PointCloud_Cross_xS,
+    # # TAX3D+PN2 (self-atten)
+    # "PN2_DiT_PointCloud_xS": PN2_DiT_PointCloud_xS,
+    # # Feature_TAX3D+PN2
+    # "PN2_DiT_PointCloud_Cross_Flow_Feature_xS": PN2_DiT_PointCloud_Cross_Flow_Feature_xS,
 
 }
 
@@ -101,7 +105,8 @@ def get_model(model_cfg):
     # feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
     # encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
     # model_name = f"{encoder}DiT_PointCloud_{cross}{feature}{model_cfg.size}"
-    model_name = f"DiT_PointCloud_{cross}{model_cfg.size}"
+    joint = "Joint_" if model_cfg.joint_encode else ""
+    model_name = f"DiT_PointCloud_{cross}{joint}{model_cfg.size}"
     return DiT_models[model_name]
 
 

--- a/src/non_rigid/models/tax3d.py
+++ b/src/non_rigid/models/tax3d.py
@@ -47,46 +47,32 @@ def DiT_pcu_xS(**kwargs):
 def DiT_pcu_cross_xS(**kwargs):
     return DiT_PointCloud_Unc_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_Cross_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
-    hidden_size = 132 if use_rotary else 128
-    return DiT_PointCloud_Cross(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+def DiT_PointCloud_Cross_xS(**kwargs):
+    return DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
+def DiT_PointCloud_xS(**kwargs):
     print("DiffusionTransformerNetwork: DiT_PointCloud_xS")
-    hidden_size = 132 if use_rotary else 128
-    return DiT_PointCloud(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+    return DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_Cross_Point_Feature_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
+def DiT_PointCloud_Cross_Point_Feature_xS(**kwargs):
     print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Point_Feature_xS")
-    hidden_size = 132 if use_rotary else 128
-    return DiT_PointCloud_Cross_Point_Feature(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+    return DiT_PointCloud_Cross_Point_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def DiT_PointCloud_Cross_Flow_Feature_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
+def DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
     print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Flow_Feature_xS")
-    hidden_size = 132 if use_rotary else 128
-    return DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+    return DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def PN2_DiT_PointCloud_Cross_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
+def PN2_DiT_PointCloud_Cross_xS(**kwargs):
     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_xS")
-    hidden_size = 132 if use_rotary else 128
-    return PN2_DiT_PointCloud_Cross(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+    return PN2_DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def PN2_DiT_PointCloud_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
+def PN2_DiT_PointCloud_xS(**kwargs):
     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_xS")
-    hidden_size = 132 if use_rotary else 128
-    return PN2_DiT_PointCloud(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+    return PN2_DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-def PN2_DiT_PointCloud_Cross_Flow_Feature_xS(use_rotary, **kwargs):
-    # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
+def PN2_DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_Flow_Feature_xS")
-    hidden_size = 132 if use_rotary else 128
-    return PN2_DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=hidden_size, num_heads=4, **kwargs)
+    return PN2_DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
 # TODO: clean up all unused functions
 DiT_models = {
@@ -114,8 +100,6 @@ def get_model(model_cfg):
     cross = "Cross_" if model_cfg.cross_atten else ""
     feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
     encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
-
-    # model_name = f"{rotary}DiT_pcu_{cross}{model_cfg.size}"
     model_name = f"{encoder}DiT_PointCloud_{cross}{feature}{model_cfg.size}"
     return DiT_models[model_name]
 
@@ -127,7 +111,6 @@ class DiffusionTransformerNetwork(nn.Module):
     def __init__(self, model_cfg=None):
         super().__init__()
         self.dit = get_model(model_cfg)(
-            use_rotary=False,
             in_channels=model_cfg.in_channels,
             learn_sigma=model_cfg.learn_sigma,
             model_cfg=model_cfg,

--- a/src/non_rigid/models/tax3d.py
+++ b/src/non_rigid/models/tax3d.py
@@ -24,7 +24,6 @@ from non_rigid.models.dit.diffusion import create_diffusion
 from non_rigid.models.dit.models import DiT_PointCloud_Unc as DiT_pcu
 from non_rigid.models.dit.models import (
     DiT_PointCloud_Unc_Cross,
-    Rel3D_DiT_PointCloud_Unc_Cross,
     DiT_PointCloud_Cross,
     DiT_PointCloud,
     DiT_PointCloud_Cross_Point_Feature,
@@ -47,13 +46,6 @@ def DiT_pcu_xS(**kwargs):
 
 def DiT_pcu_cross_xS(**kwargs):
     return DiT_PointCloud_Unc_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-
-def Rel3D_DiT_pcu_cross_xS(**kwargs):
-    # Embed dim divisible by 3 for 3D positional encoding and divisible by num_heads for multi-head attention
-    return Rel3D_DiT_PointCloud_Unc_Cross(
-        depth=5, hidden_size=132, num_heads=4, **kwargs
-    )
 
 def DiT_PointCloud_Cross_xS(use_rotary, **kwargs):
     # hidden size divisible by 3 for rotary embedding, and divisible by num_heads for multi-head attention
@@ -101,8 +93,6 @@ DiT_models = {
     "DiT_pcu_S": DiT_pcu_S,
     "DiT_pcu_xS": DiT_pcu_xS,
     "DiT_pcu_cross_xS": DiT_pcu_cross_xS,
-    "Rel3D_DiT_pcu_cross_xS": Rel3D_DiT_pcu_cross_xS,
-    # there is no Rel3D_DiT_pcu_xS
     "DiT_PointCloud_Cross_xS": DiT_PointCloud_Cross_xS,
     # TODO: add the SD model here
     "DiT_PointCloud_xS": DiT_PointCloud_xS,
@@ -121,7 +111,6 @@ DiT_models = {
 
 
 def get_model(model_cfg):
-    #rotary = "Rel3D_" if model_cfg.rotary else ""
     cross = "Cross_" if model_cfg.cross_atten else ""
     feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
     encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
@@ -138,7 +127,7 @@ class DiffusionTransformerNetwork(nn.Module):
     def __init__(self, model_cfg=None):
         super().__init__()
         self.dit = get_model(model_cfg)(
-            use_rotary=model_cfg.rotary,
+            use_rotary=False,
             in_channels=model_cfg.in_channels,
             learn_sigma=model_cfg.learn_sigma,
             model_cfg=model_cfg,

--- a/src/non_rigid/models/tax3d.py
+++ b/src/non_rigid/models/tax3d.py
@@ -22,30 +22,11 @@ from non_rigid.metrics.flow_metrics import flow_cos_sim, flow_rmse, pc_nn
 from non_rigid.metrics.rigid_metrics import svd_estimation, translation_err, rotation_err
 from non_rigid.models.dit.diffusion import create_diffusion
 from non_rigid.models.dit.models import (
-    # DiT_PointCloud_Unc_Cross,
     DiT_PointCloud_Cross,
     DiT_PointCloud_Cross_Joint,
-    # DiT_PointCloud,
-    # DiT_PointCloud_Cross_Point_Feature,
-    # DiT_PointCloud_Cross_Flow_Feature,
-    # PN2_DiT_PointCloud_Cross,
-    # PN2_DiT_PointCloud,
-    # PN2_DiT_PointCloud_Cross_Flow_Feature,
 )
 from non_rigid.utils.logging_utils import viz_predicted_vs_gt
 from non_rigid.utils.pointcloud_utils import expand_pcd
-
-
-# def DiT_pcu_S(**kwargs):
-#     return DiT_pcu(depth=12, hidden_size=384, num_heads=6, **kwargs)
-
-
-# def DiT_pcu_xS(**kwargs):
-#     return DiT_pcu(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-
-# def DiT_pcu_cross_xS(**kwargs):
-#     return DiT_PointCloud_Unc_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
 def DiT_PointCloud_Cross_xS(**kwargs):
     return DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
@@ -53,58 +34,14 @@ def DiT_PointCloud_Cross_xS(**kwargs):
 def DiT_PointCloud_Cross_Joint_xS(**kwargs):
     return DiT_PointCloud_Cross_Joint(depth=5, hidden_size=128, num_heads=4, **kwargs)
 
-# def DiT_PointCloud_xS(**kwargs):
-#     print("DiffusionTransformerNetwork: DiT_PointCloud_xS")
-#     return DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-# def DiT_PointCloud_Cross_Point_Feature_xS(**kwargs):
-#     print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Point_Feature_xS")
-#     return DiT_PointCloud_Cross_Point_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-# def DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
-#     print("DiffusionTransformerNetwork: DiT_PointCloud_Cross_Flow_Feature_xS")
-#     return DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-# def PN2_DiT_PointCloud_Cross_xS(**kwargs):
-#     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_xS")
-#     return PN2_DiT_PointCloud_Cross(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-# def PN2_DiT_PointCloud_xS(**kwargs):
-#     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_xS")
-#     return PN2_DiT_PointCloud(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-# def PN2_DiT_PointCloud_Cross_Flow_Feature_xS(**kwargs):
-#     print("DiffusionTransformerNetwork: PN2_DiT_PointCloud_Cross_Flow_Feature_xS")
-#     return PN2_DiT_PointCloud_Cross_Flow_Feature(depth=5, hidden_size=128, num_heads=4, **kwargs)
-
-# TODO: clean up all unused functions
 DiT_models = {
-    # "DiT_pcu_S": DiT_pcu_S,
-    # "DiT_pcu_xS": DiT_pcu_xS,
-    # "DiT_pcu_cross_xS": DiT_pcu_cross_xS,
     "DiT_PointCloud_Cross_xS": DiT_PointCloud_Cross_xS,
     "DiT_PointCloud_Cross_Joint_xS": DiT_PointCloud_Cross_Joint_xS,
-    # # TODO: add the SD model here
-    # "DiT_PointCloud_xS": DiT_PointCloud_xS,
-    # # option 1
-    # "DiT_PointCloud_Cross_Point_Feature_xS": DiT_PointCloud_Cross_Point_Feature_xS,
-    # # option 2
-    # "DiT_PointCloud_Cross_Flow_Feature_xS": DiT_PointCloud_Cross_Flow_Feature_xS,
-    # # TAX3D+PN2 (cross-atten)
-    # "PN2_DiT_PointCloud_Cross_xS": PN2_DiT_PointCloud_Cross_xS,
-    # # TAX3D+PN2 (self-atten)
-    # "PN2_DiT_PointCloud_xS": PN2_DiT_PointCloud_xS,
-    # # Feature_TAX3D+PN2
-    # "PN2_DiT_PointCloud_Cross_Flow_Feature_xS": PN2_DiT_PointCloud_Cross_Flow_Feature_xS,
-
 }
 
 
 def get_model(model_cfg):
     cross = "Cross_" if model_cfg.cross_atten else ""
-    # feature = "Point_Feature_" if model_cfg.feature == "point" else "Flow_Feature_" if model_cfg.feature == "flow" else ""
-    # encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""
-    # model_name = f"{encoder}DiT_PointCloud_{cross}{feature}{model_cfg.size}"
     joint = "Joint_" if model_cfg.joint_encode else ""
     model_name = f"DiT_PointCloud_{cross}{joint}{model_cfg.size}"
     return DiT_models[model_name]

--- a/src/non_rigid/models/tax3d_ddrd.py
+++ b/src/non_rigid/models/tax3d_ddrd.py
@@ -46,7 +46,6 @@ DiT_models = {
 }
 
 def get_model(model_cfg):
-    #rotary = "Rel3D_" if model_cfg.rotary else ""
     cross = "Cross_" if model_cfg.cross_atten else ""
     feature = "Feature_" if model_cfg.feature else ""
     encoder = "PN2_" if model_cfg.encoder_backbone == "pn2" else ""

--- a/src/non_rigid/nets/pn2.py
+++ b/src/non_rigid/nets/pn2.py
@@ -1,0 +1,393 @@
+# PointNet++ implementation
+# Code borrowed from: https://github.com/liy1shu/FlowBotHD/blob/main/src/flowbothd/models/modules/pn2.py
+
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from rpad.pyg.nets import pointnet2 as pnp_bn
+from rpad.pyg.nets.mlp import MLP, MLPParams
+from torch_geometric.data import Data
+from torch_geometric.nn import PointConv, fps, global_max_pool, knn_interpolate, radius
+
+
+@dataclass
+class SAParams:
+    # Ratio of points to sample.
+    ratio: float
+
+    # Radius for the ball query.
+    r: float
+
+    # Parameters for the PointNet MLP.
+    net_params: MLPParams
+
+    # Maximum number of neighbors for the ball query to return.
+    max_num_neighbors: int = 64
+
+
+class SAModule(nn.Module):
+    def __init__(self, in_chan: int, out_chan: int, p: SAParams):
+        """Create a Set Aggregation module from PointNet++.
+
+        Algorithm:
+          1) Perform "farthest point sampling", selecting a number of points proportional
+             to the specified ratio. i.e. if the input has 10000 points and the ratio is .2,
+             we select 2000 points with FPS.
+          2) For each selected points, get all points within radius r, up to max_num_neighbors.
+          3) Run PointNet (vanilla) on each region independently.
+
+        Args:
+            p (SAParams) See above.
+
+        """
+        super(SAModule, self).__init__()
+        self.ratio = p.ratio
+        self.max_num_neighbors = p.max_num_neighbors
+        self.r = p.r
+
+        # NOTE: "add_self_loops" for some reason breaks the gradient flow in a batch!!!
+        # See my bug at https://github.com/rusty1s/pytorch_geometric/issues/2558
+        self.conv = PointConv(
+            MLP(in_chan, out_chan, p.net_params), add_self_loops=False
+        )
+
+    def forward(self, x, pos, batch):
+        if self.ratio == 1.0:
+            selected_pos = pos
+            selected_batch = batch
+        else:
+            # Select the points using "Farthest Point Sampling".
+            idx = fps(pos, batch, ratio=self.ratio)
+
+            selected_pos = pos[idx]
+            selected_batch = batch[idx]
+
+        # Perform a ball query around each of the points.
+        row, col = radius(
+            pos,
+            selected_pos,
+            self.r,
+            batch,
+            selected_batch,
+            max_num_neighbors=self.max_num_neighbors,
+        )
+
+        # Run PointNet on each point set independently.
+        edge_index = torch.stack([col, row], dim=0)
+        x = self.conv(x, (pos, selected_pos), edge_index)
+        pos, batch = selected_pos, selected_batch
+
+        return x, pos, batch
+
+
+@dataclass
+class GlobalSAParams:
+    net_params: MLPParams
+
+
+class GlobalSAModule(nn.Module):
+    def __init__(self, in_chan: int, out_chan: int, p: GlobalSAParams):
+        """Module to perform the Global Set Aggregation operation.
+
+        Two steps:
+        1) For each point, apply the mlp specified in net_params.
+        2) Use the global_max_pool operation to get a final feature vector.
+
+        Args:
+            p (GlobalSAParams): Parameters.
+        """
+        super(GlobalSAModule, self).__init__()
+        self.net = MLP(in_chan, out_chan, p.net_params)
+
+    def forward(self, x, pos, batch):
+        # Batch application of the MLP.
+        x = self.net(torch.cat([x, pos], dim=1))
+
+        # MaxPool operation.
+        x = global_max_pool(x, batch)
+        pos = pos.new_zeros((x.size(0), 3))
+        batch = torch.arange(x.size(0), device=batch.device)
+        return x, pos, batch
+
+
+@dataclass
+class FPParams:
+    # MLP Parameters for the feature update step.
+    net_params: MLPParams
+
+    # Number of neighbors used for knn_interpolate.
+    k: int = 3
+
+
+class FPModule(torch.nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, params: FPParams):
+        """Feature Propagation Module.
+
+        1) Interpolate each point based on the k nearest embedded points.
+        2) Concatenate skip features.
+        3) Update feature vectors with another MLP.
+
+        Args:
+            params (FPParams): Parameters.
+
+        """
+        super().__init__()
+        self.k = params.k
+        self.net = MLP(in_channels, out_channels, params.net_params)
+
+    def forward(self, x, pos, batch, x_skip, pos_skip, batch_skip):
+        # If we need to interpolate, interpolate.
+        # Otherwise (i.e. when the sampling ratio is 1.0, we don't need to.
+        if pos.shape[0] != pos_skip.shape[0]:
+            # Perform the interpolation.
+            x = knn_interpolate(x, pos, pos_skip, batch, batch_skip, k=self.k)
+
+        # If we have skip connections concatenate them.
+        if x_skip is not None:
+            x = torch.cat([x, x_skip], dim=1)
+
+        # Run them
+        x = self.net(x)
+
+        return x, pos_skip, batch_skip
+
+
+@dataclass
+class PN2EncoderParams:
+    # Layer 1. See SAParams for description.
+    sa1: SAParams = SAParams(0.2, 0.2, MLPParams((64, 64), batch_norm=False), 64)
+    sa1_outdim: int = 128
+
+    # Layer 2. See SAParams for description.
+    sa2: SAParams = SAParams(0.25, 0.4, MLPParams((128, 128), batch_norm=False), 64)
+    sa2_outdim: int = 256
+
+    # Global aggregation. See GlobalSAParams for description.
+    gsa: GlobalSAParams = GlobalSAParams(MLPParams((256, 512), batch_norm=False))
+
+
+class PN2Encoder(nn.Module):
+    def __init__(
+        self,
+        in_dim: int = 0,
+        out_dim: int = 1024,
+        p: PN2EncoderParams = PN2EncoderParams(),
+    ):
+        """A PointNet++ encoder. Takes in a pointcloud, outputs a single latent vector.
+
+        Args:
+            in_dim: The dimensionality of the feature vector attached to each point. i.e. if it's
+                    a mask, then in_dim=1. No features => in_dim=1
+            out_dim: Dimensionality of the output.
+            p: Internal parameters for the network.
+        """
+        super().__init__()
+
+        # The Set Aggregation modules.
+        self.sa1_module = SAModule(in_chan=3 + in_dim, out_chan=p.sa1_outdim, p=p.sa1)
+        self.sa2_module = SAModule(
+            in_chan=3 + p.sa1_outdim, out_chan=p.sa2_outdim, p=p.sa2
+        )
+        self.sa3_module = GlobalSAModule(
+            in_chan=3 + p.sa2_outdim, out_chan=out_dim, p=p.gsa
+        )
+
+    def forward(self, data):
+        sa0_out = (data.x, data.pos, data.batch)
+        sa1_out = self.sa1_module(*sa0_out)
+        sa2_out = self.sa2_module(*sa1_out)
+        sa3_out = self.sa3_module(*sa2_out)
+        x, pos, batch = sa3_out
+
+        return x
+
+
+@dataclass
+class PN2DenseParams:
+    ###########################################################################
+    # SET AGGREGATION
+    ###########################################################################
+
+    # Layer 1. See SAParams for description.
+    sa1: SAParams = SAParams(
+        0.2, 0.2, MLPParams((64, 64), out_act="none", batch_norm=False), 64
+    )
+    sa1_outdim: int = 128
+
+    # Layer 2. See SAParams for description.
+    sa2: SAParams = SAParams(
+        0.25, 0.4, MLPParams((128, 128), out_act="none", batch_norm=False), 64
+    )
+    sa2_outdim: int = 256
+
+    # Global aggregation. See GlobalSAParams for description.
+    gsa: GlobalSAParams = GlobalSAParams(
+        MLPParams((256, 512), out_act="none", batch_norm=False)
+    )
+    gsa_outdim: int = 1024
+
+    ###########################################################################
+    # FEATURE PROPAGATION
+    # Since this is the decoder, execution happens 3->2->1.
+    ###########################################################################
+
+    # Layer 3. See FPParams for description.
+    fp3: FPParams = FPParams(MLPParams((256,), out_act="none", batch_norm=False), k=1)
+
+    # Layer 2. See FPParams for description.
+    fp2: FPParams = FPParams(MLPParams((256,), out_act="none", batch_norm=False), k=3)
+
+    # Layer 1. See FPParams for description.
+    fp1: FPParams = FPParams(
+        MLPParams((128, 128), out_act="none", batch_norm=False), k=3
+    )
+    fp1_outdim: int = 128
+
+    # Dimensions of the final 2 linear layers.
+    lin1_dim: int = 128
+    lin2_dim: int = 128
+
+    # Output layer activation.
+    out_act: Literal["none", "softmax", "relu"] = "none"
+
+
+class PN2Dense(nn.Module):
+    def __init__(
+        self,
+        in_channels: int = 0,
+        out_channels: int = 3,
+        p: PN2DenseParams = PN2DenseParams(),
+    ):
+        """The PointNet++ "dense" network architecture, as proposed in the original paper.
+        In general, the parameters "p" are architecture or hyperparameter choices for the network.
+        The other arguments are structural ones, determining the input and output dimensionality.
+
+        It's a bit of a U-Net architecture, so I've written some automatic wiring to make sure that
+        the layers all agree.
+
+        Args:
+            in_channels: The number of non-XYZ channels attached to each point. For instance, no additional
+                         features would have in_channels=0, RGB features would be in_channels=3, a binary mask
+                         would be in_channels=1, etc. For a point cloud passed to the network with N points,
+                         the `x` property must be set on the object to a float tensor of shape [N x in_channels].
+            out_channels: The dimension of the per-point output channels.
+            p: Architecture and hyperparameters for the network. Default is the original set from the paper.
+        """
+        super().__init__()
+
+        self.in_ch = in_channels
+        self.out_ch = out_channels
+
+        # Construct the set aggregation modules. This is the encoder.
+        self.sa1 = SAModule(3 + self.in_ch, p.sa1_outdim, p=p.sa1)
+        self.sa2 = SAModule(3 + p.sa1_outdim, p.sa2_outdim, p=p.sa2)
+        self.sa3 = GlobalSAModule(3 + p.sa2_outdim, p.gsa_outdim, p=p.gsa)
+
+        # The Feature Propagation modules. This is the decoder.
+        self.fp3 = FPModule(p.gsa_outdim + p.sa2_outdim, p.sa2_outdim, p.fp3)
+        self.fp2 = FPModule(p.sa2_outdim + p.sa1_outdim, p.sa1_outdim, p.fp2)
+        self.fp1 = FPModule(p.sa1_outdim + in_channels, p.fp1_outdim, p.fp1)
+
+        # Final linear layers at the output.
+        self.lin1 = torch.nn.Linear(p.fp1_outdim, p.lin1_dim)
+        self.lin2 = torch.nn.Linear(p.lin1_dim, p.lin2_dim)
+        self.lin3 = torch.nn.Linear(p.lin2_dim, out_channels)
+        self.out_act = p.out_act
+
+    def forward(self, data: Data):
+        sa0_out = (data.x, data.pos, data.batch)
+
+        # Encode.
+        sa1_out = self.sa1(*sa0_out)
+        sa2_out = self.sa2(*sa1_out)
+        sa3_out = self.sa3(*sa2_out)
+
+        # Decode.
+        fp3_out = self.fp3(*sa3_out, *sa2_out)
+        fp2_out = self.fp2(*fp3_out, *sa1_out)
+        x, _, _ = self.fp1(*fp2_out, *sa0_out)
+
+        # Final layers.
+        x = F.leaky_relu(self.lin1(x))
+        x = F.leaky_relu(self.lin2(x))
+        x = self.lin3(x)
+
+        if self.out_act != "none":
+            raise ValueError()
+
+        return x
+
+
+class PN2DenseLatentEncodingEverywhere(nn.Module):
+    def __init__(
+        self,
+        history_embed_dim,
+        in_channels: int = 0,
+        out_channels: int = 3,
+        p: pnp_bn.PN2DenseParams = pnp_bn.PN2DenseParams(),  # With Batch Norm
+    ):
+        super().__init__()
+
+        self.in_ch = in_channels
+        self.out_ch = out_channels
+        # Construct the set aggregation modules. This is the encoder.
+        self.sa1 = SAModule(3 + self.in_ch, p.sa1_outdim, p=p.sa1)
+        self.sa2 = SAModule(3 + p.sa1_outdim, p.sa2_outdim, p=p.sa2)
+        self.sa3 = GlobalSAModule(3 + p.sa2_outdim, p.gsa_outdim, p=p.gsa)
+
+        # The Feature Propagation modules. This is the decoder.
+        self.fp3 = FPModule(p.gsa_outdim + p.sa2_outdim, p.sa2_outdim, p.fp3)
+        self.fp2 = FPModule(p.sa2_outdim + p.sa1_outdim, p.sa1_outdim, p.fp2)
+        self.fp1 = FPModule(p.sa1_outdim + in_channels, p.fp1_outdim, p.fp1)
+
+        # Linear projection layers to incorporate the flwo embedding.
+        # Option: could add relu?
+        self.global_linear = torch.nn.Linear(history_embed_dim, p.gsa_outdim)
+        self.fp3_embedding_linear = torch.nn.Linear(history_embed_dim, p.sa2_outdim)
+        self.fp2_embedding_linear = torch.nn.Linear(history_embed_dim, p.sa1_outdim)
+        self.fp1_embedding_linear = torch.nn.Linear(history_embed_dim, p.fp1_outdim)
+
+        # Final linear layers at the output.
+        self.lin1 = torch.nn.Linear(p.fp1_outdim, p.lin1_dim)
+        self.lin2 = torch.nn.Linear(p.lin1_dim, p.lin2_dim)
+        self.lin3 = torch.nn.Linear(p.lin2_dim, out_channels)
+        self.out_act = p.out_act
+
+    def forward(self, data: Data, latents):
+        sa0_out = (data.x, data.pos, data.batch)
+        # Encode.
+        sa1_out = self.sa1(*sa0_out)
+        sa2_out = self.sa2(*sa1_out)
+        x3, pos3, batch3 = self.sa3(*sa2_out)
+
+        # No concatenation! just hadamard!
+        x3 = self.global_linear(latents) * x3
+        sa3_out = x3, pos3, batch3
+
+        # Decode.
+        x_fp3, pos_fp3, batch_fp3 = self.fp3(*sa3_out, *sa2_out)
+        fp3_latents = self.fp3_embedding_linear(latents)
+        x_fp3 = fp3_latents.repeat_interleave(torch.bincount(batch_fp3), dim=0) * x_fp3
+        fp3_out = x_fp3, pos_fp3, batch_fp3
+
+        x_fp2, pos_fp2, batch_fp2 = self.fp2(*fp3_out, *sa1_out)
+        fp2_latents = self.fp2_embedding_linear(latents)
+        x_fp2 = fp2_latents.repeat_interleave(torch.bincount(batch_fp2), dim=0) * x_fp2
+        fp2_out = x_fp2, pos_fp2, batch_fp2
+
+        x, _, batch_fp1 = self.fp1(*fp2_out, *sa0_out)
+        fp1_latents = self.fp1_embedding_linear(latents)
+        x = fp1_latents.repeat_interleave(torch.bincount(batch_fp1), dim=0) * x
+
+        # Final layers.
+        x = F.leaky_relu(self.lin1(x))
+        x = F.leaky_relu(self.lin2(x))
+        x = self.lin3(x)
+
+        if self.out_act != "none":
+            raise ValueError()
+
+        return x

--- a/src/non_rigid/utils/script_utils.py
+++ b/src/non_rigid/utils/script_utils.py
@@ -138,9 +138,13 @@ def create_datamodule(cfg):
             f"Model type: '{cfg.model.type}' and dataset type: '{cfg.dataset.type}' are incompatible."
         )
     
+    # setting model-specific dataset params
     cfg.dataset.noisy_goal = cfg.model.noisy_goal
     cfg.dataset.center_type = cfg.model.center_type
     cfg.dataset.action_context_center_type = cfg.model.action_context_center_type
+
+    # setting dataset-specific model params
+    cfg.model.pcd_scale = cfg.dataset.pcd_scale
 
     # TODO: Unify these flags !
     # Currently: 

--- a/src/non_rigid/utils/script_utils.py
+++ b/src/non_rigid/utils/script_utils.py
@@ -132,7 +132,8 @@ def create_model(cfg):
 
 def create_datamodule(cfg):
     # check that dataset and model types are compatible
-    if cfg.model.type != cfg.dataset.type:
+    # TODO: eventually, remove this entire code snippet
+    if "type" in cfg.dataset and cfg.model.type != cfg.dataset.type:
         raise ValueError(
             f"Model type: '{cfg.model.type}' and dataset type: '{cfg.dataset.type}' are incompatible."
         )
@@ -180,11 +181,13 @@ def create_datamodule(cfg):
     datamodule.setup(stage)
 
     # updating job config sample sizes
-    if cfg.dataset.scene:
-        job_cfg.sample_size = cfg.dataset.sample_size_action + cfg.dataset.sample_size_anchor
-    else:
-        job_cfg.sample_size = cfg.dataset.sample_size_action
-        job_cfg.sample_size_anchor = cfg.dataset.sample_size_anchor
+    # if cfg.dataset.scene:
+    #     job_cfg.sample_size = cfg.dataset.sample_size_action + cfg.dataset.sample_size_anchor
+    # else:
+    #     job_cfg.sample_size = cfg.dataset.sample_size_action
+    #     job_cfg.sample_size_anchor = cfg.dataset.sample_size_anchor
+    job_cfg.sample_size = cfg.dataset.sample_size_action
+    job_cfg.sample_size_anchor = cfg.dataset.sample_size_anchor
 
     # training-specific job config setup
     if cfg.mode == "train":

--- a/src/non_rigid/utils/script_utils.py
+++ b/src/non_rigid/utils/script_utils.py
@@ -137,6 +137,10 @@ def create_datamodule(cfg):
         raise ValueError(
             f"Model type: '{cfg.model.type}' and dataset type: '{cfg.dataset.type}' are incompatible."
         )
+    
+    cfg.dataset.noisy_goal = cfg.model.noisy_goal
+    cfg.dataset.center_type = cfg.model.center_type
+    cfg.dataset.action_context_center_type = cfg.model.action_context_center_type
 
     # TODO: Unify these flags !
     # Currently: 


### PR DESCRIPTION
Goal is to streamline the config structure so that:

- experiments can be run easily by switching individual config parameters. 
- older legacy parameters are removed to avoid confusion.
- model-specific parameters are contained/set by the model config, rather than by the dataset config (e.g. the centering type for action or anchor point cloud).

Also cleaning up shell script usage for simplicity, and restructuring/consolidating model code so that there isn't a new model implementation for each config setting.